### PR TITLE
hal_mgr: move code to class and add ready topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ The files may be either legacy `.hal` files or python scripts.
 See the `config/hal_hw_interface.yaml` and `config/hal_io.yaml` files
 in `hal_rrbot_control` for typical configuration examples.
 
+When the hal_mgr completes loading the HAL files, it sets 'hal_mgr/ready'
+topic to true. Other processes can use this topic to check the status
+loading the HAL configuration.
+
 ### `hal_hw_interface` configuration
 
 A `hal_hw_interface` configuration builds on an existing

--- a/hal_hw_interface/scripts/hal_mgr
+++ b/hal_hw_interface/scripts/hal_mgr
@@ -32,115 +32,16 @@
 # OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-import sys
 import os
-import subprocess
-import signal
 
-from machinekit import launcher, config, rtapi
-
-# ROS
-import rospy
+from hal_hw_interface import hal_mgr
 
 MAIN_HAL = 'main.py'
 NAME = 'hal_mgr'
 HAL_IO = 'hal_io'
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
-os.chdir(SCRIPT_DIR)
 
-debug = int(os.environ.get('DEBUG', 0))
-launcher.set_debug_level(debug)
-
-shutdown_begun = False
-
-
-def shutdown(msg="Shutting down for unknown reason", res=0):
-    # Only run this once
-    global shutdown_begun
-    if shutdown_begun:
-        return
-    shutdown_begun = True
-
-    if res:
-        rospy.logerr("hal_mgr:  %s" % msg)
-    else:
-        rospy.loginfo("hal_mgr:  %s" % msg)
-    launcher.end_session()
-    rospy.signal_shutdown(msg)
-    sys.exit(res)
-
-
-if 'MACHINEKIT_INI' not in os.environ:  # export for package installs
-    mkconfig = config.Config()
-    os.environ['MACHINEKIT_INI'] = mkconfig.MACHINEKIT_INI
-
-try:
-    # Set up ROS node
-    rospy.init_node(NAME)
-    # Call end_session() on ROS shutdown; don't have the launcher
-    # register its own exit handler
-    rospy.on_shutdown(lambda: shutdown('Graceful shutdown via ROS'))
-    rate = rospy.Rate(1)  # 1hz
-    rospy.loginfo("hal_mgr:  Initialized node")
-
-    # Find the hal_hw_interface comp's directory in LD_LIBRARY_PATH and put it
-    # into $COMP_DIR
-    comp_dir = ""
-    for path in os.environ.get('LD_LIBRARY_PATH', '').split(':'):
-        if os.path.exists(os.path.join(path, 'hal_hw_interface.so')):
-            comp_dir = path
-    os.environ['COMP_DIR'] = comp_dir
-    rospy.loginfo("hal_mgr:  COMP_DIR set to '%s'" % comp_dir)
-
-    # Get parameters
-    if not rospy.has_param(NAME):
-        shutdown("No parameters set for '%s'" % NAME, 1)
-    try:
-        hal_mgr_config = rospy.get_param(NAME)
-    except KeyError:
-        shutdown("No keys defined at %s" % NAME, 1)
-    if 'hal_files' not in hal_mgr_config:
-        shutdown("%s has no 'hal_files' key" % NAME, 1)
-    if 'hal_file_dir' not in hal_mgr_config:
-        shutdown("%s has no 'hal_file_dir' key" % NAME, 1)
-
-    # Set up HAL
-    launcher.cleanup_session()  # kill any running Machinekit instances
-    launcher.start_realtime()
-    rospy.loginfo("hal_mgr:  Started realtime")
-
-    # Load rtapi module and set up signal handlers
-    if not rtapi.__rtapicmd:
-        rtapi.init_RTAPI()
-
-    def shutdown_graceful(signum, frame):
-        shutdown('Gracefully shutting down after interrupt signal')
-
-    signal.signal(signal.SIGINT, shutdown_graceful)
-    signal.signal(signal.SIGTERM, shutdown_graceful)
-
-    # Load HAL configuration
-    for fname in hal_mgr_config['hal_files']:
-        fpath = os.path.join(hal_mgr_config['hal_file_dir'], fname)
-        if not os.path.exists(fpath):
-            shutdown(
-                "No file '%s' in directory '%s'"
-                % (fname, hal_mgr_config['hal_file_dir'])
-            )
-        rospy.loginfo("hal_mgr:  Loading hal file '%s'" % fname)
-        launcher.load_hal_file(fpath)
-        rospy.loginfo("hal_mgr:  Loading hal file '%s' complete" % fpath)
-
-    # Spin until ROS shutdown event
-    rospy.loginfo("ROS node and HAL started successfully")
-    while not rospy.is_shutdown():
-        launcher.check_processes()
-        rate.sleep()
-
-except subprocess.CalledProcessError as e:
-    shutdown("Process error:  %s" % e, 1)
-except rospy.ROSInterruptException as e:
-    shutdown("Interrupt:  %s" % e, 0)
-
-shutdown("Shutting down", 0)
+if __name__ == '__main__':
+    os.chdir(SCRIPT_DIR)
+    hal_mgr.main()

--- a/hal_hw_interface/src/hal_hw_interface/hal_mgr.py
+++ b/hal_hw_interface/src/hal_hw_interface/hal_mgr.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+import sys
+import os
+import subprocess
+import signal
+
+from machinekit import launcher, config, rtapi
+
+# ROS
+import rospy
+from std_msgs.msg import Bool
+
+
+class HalMgr(object):
+    NAME = 'hal_mgr'
+    READY_TOPIC = "hal_mgr/ready"
+    shutdown_begun = False
+
+    def __init__(self):
+        # Set up ROS node
+        rospy.init_node(self.NAME)
+        # Call end_session() on ROS shutdown; don't have the launcher
+        # register its own exit handler
+        rospy.on_shutdown(lambda: self.shutdown('Graceful shutdown via ROS'))
+        self._rate = rospy.Rate(1)  # 1hz
+        rospy.loginfo("hal_mgr:  Initialized node")
+
+        self._pub = rospy.Publisher(
+            self.READY_TOPIC, Bool, queue_size=1, latch=True
+        )
+
+    def start(self):
+        # Find the hal_hw_interface comp's directory in LD_LIBRARY_PATH and put it
+        # into $COMP_DIR
+        comp_dir = ""
+        for path in os.environ.get('LD_LIBRARY_PATH', '').split(':'):
+            if os.path.exists(os.path.join(path, 'hal_hw_interface.so')):
+                comp_dir = path
+        os.environ['COMP_DIR'] = comp_dir
+        rospy.loginfo("hal_mgr:  COMP_DIR set to '%s'" % comp_dir)
+
+        # Get parameters
+        if not rospy.has_param(self.NAME):
+            self.shutdown("No parameters set for '%s'" % self.NAME, 1)
+        try:
+            hal_mgr_config = rospy.get_param(self.NAME)
+        except KeyError:
+            self.shutdown("No keys defined at %s" % self.NAME, 1)
+            return
+
+        if 'hal_files' not in hal_mgr_config:
+            self.shutdown("%s has no 'hal_files' key" % self.NAME, 1)
+        if 'hal_file_dir' not in hal_mgr_config:
+            self.shutdown("%s has no 'hal_file_dir' key" % self.NAME, 1)
+
+        # Set up HAL
+        launcher.cleanup_session()  # kill any running Machinekit instances
+        launcher.start_realtime()
+        rospy.loginfo("hal_mgr:  Started realtime")
+
+        # Load rtapi module and set up signal handlers
+        if not getattr(rtapi, '__rtapicmd'):
+            rtapi.init_RTAPI()
+
+        def shutdown_graceful(signum, frame):
+            self.shutdown('Gracefully shutting down after interrupt signal')
+
+        signal.signal(signal.SIGINT, shutdown_graceful)
+        signal.signal(signal.SIGTERM, shutdown_graceful)
+
+        # Load HAL configuration
+        for fname in hal_mgr_config['hal_files']:
+            fpath = os.path.join(hal_mgr_config['hal_file_dir'], fname)
+            if not os.path.exists(fpath):
+                self.shutdown(
+                    "No file '%s' in directory '%s'"
+                    % (fname, hal_mgr_config['hal_file_dir'])
+                )
+            rospy.loginfo("hal_mgr:  Loading hal file '%s'" % fname)
+            launcher.load_hal_file(fpath)
+            rospy.loginfo("hal_mgr:  Loading hal file '%s' complete" % fpath)
+
+        # Spin until ROS shutdown event
+        rospy.loginfo("ROS node and HAL started successfully")
+        self._pub.publish(True)
+
+    def loop(self):
+        while not rospy.is_shutdown():
+            launcher.check_processes()
+            self._rate.sleep()
+
+    def shutdown(self, msg="Shutting down for unknown reason", res=0):
+        # Only run this once
+        if self.shutdown_begun:
+            return
+        self.shutdown_begun = True
+
+        if res:
+            rospy.logerr("hal_mgr:  %s" % msg)
+        else:
+            rospy.loginfo("hal_mgr:  %s" % msg)
+        self._pub.publish(False)
+        launcher.end_session()
+        rospy.signal_shutdown(msg)
+        sys.exit(res)
+
+
+def main():
+    debug = int(os.environ.get('DEBUG', 0))
+    launcher.set_debug_level(debug)
+
+    if 'MACHINEKIT_INI' not in os.environ:  # export for package installs
+        mkconfig = config.Config()
+        os.environ['MACHINEKIT_INI'] = mkconfig.MACHINEKIT_INI
+
+    hal_mgr = HalMgr()
+    try:
+        hal_mgr.start()
+        hal_mgr.loop()
+    except subprocess.CalledProcessError as e:
+        hal_mgr.shutdown("Process error:  %s" % e, 1)
+    except rospy.ROSInterruptException as e:
+        hal_mgr.shutdown("Interrupt:  %s" % e, 0)
+    else:
+        hal_mgr.shutdown("Shutting down", 0)


### PR DESCRIPTION
This patch move the code of the `hal_mgr` script to a Python class.

Moreover, it adds the new `hal_mgr/ready` topic, which indicates the loading state of the HAL configuration.