### PR TITLE
2022 02 08 ros2 infrastructure updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,17 @@ repos:
   hooks:
   - id: flake8
     # note: ignores and excluded files in .flake8
+
+- repo: https://github.com/myint/docformatter
+  rev: v1.3.1
+  hooks:
+    - id: docformatter
+      args: [--pre-summary-newline, --in-place]
+
+- repo: https://github.com/pycqa/pydocstyle
+  rev: 6.1.1
+  hooks:
+  - id: pydocstyle
+    args:
+    # Match industrial_ci list
+    - --ignore=D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404

--- a/README.md
+++ b/README.md
@@ -75,14 +75,12 @@ revolute-revolute robot demo with HAL.  It is meant to show how simple
 it can be to build a `ros_control` hardware interface with HAL, and to
 serve as an example for creating your own.
 
-It also demonstrates the `hal_io` user component.  A simple gripper
-URDF is added, and a `hal_io` service pin open the gripper when
-`True` and closes when `False`.
-
 Run the simulated hardware interface:
 
     ros2 launch hal_rrbot_control rrbot.launch.py
     # Debugging: append `hal_debug_output:=1 hal_debug_level:=5`
+    # Trajectory controller:  append
+    #     `robot_controller:=position_trajectory_controller`
 
 Run `halscope` to visualize HAL joint commands and feedback; in the
 GUI, set the "Run Mode" to "Roll" for continuous updating:
@@ -93,7 +91,31 @@ The simulated trajectories are launched directly from the
 `ros2_control_demo_bringup` package:
 
     ros2 launch ros2_control_demo_bringup test_forward_position_controller.launch.py
+    # Or for robot_controller:=position_trajectory_controller:
     ros2 launch ros2_control_demo_bringup test_joint_trajectory_controller.launch.py
+
+Load and switch to the trajectory controller at run time:
+
+    # Load and configure the trajectory controller
+    ros2 service call \
+      /controller_manager/load_and_configure_controller \
+      controller_manager_msgs/srv/LoadConfigureController \
+      '{name: "position_trajectory_controller"}'
+
+    # Switch to the trajectory controller
+    ros2 service call \
+      /controller_manager/switch_controller \
+      controller_manager_msgs/srv/SwitchController \
+      '{start_controllers: ["position_trajectory_controller"],
+        stop_controllers: ["forward_position_controller"],
+        strictness: 1, start_asap: true,
+        timeout: {sec: 0, nanosec: 10000000}
+       }'
+
+    # Verify the switch: 'position_trajectory_controller' state='active'
+    ros2 service call \
+      /controller_manager/list_controllers \
+      controller_manager_msgs/srv/ListControllers
 
 -----
 ## Configuration

--- a/hal_hw_interface/hal_hw_interface/__init__.py
+++ b/hal_hw_interface/hal_hw_interface/__init__.py
@@ -2,5 +2,4 @@
 Python classes for the `hal_hw_interface` ROS package.
 
 .. moduleauthor:: John Morris <john@dovetail-automata.com>
-
 """

--- a/hal_hw_interface/hal_hw_interface/hal_io_comp.py
+++ b/hal_hw_interface/hal_hw_interface/hal_io_comp.py
@@ -15,9 +15,7 @@ class HalIO(RosHalComponent):
     :code:`hal_io/service_pins` parameters, lists of pin names to pin
     data mappings.
 
-    The pin data must be a dictionary of pin configuration.
-
-    Example:
+    The pin data must be a dictionary of pin configuration; example:
 
     .. code-block:: yaml
 

--- a/hal_hw_interface/hal_hw_interface/loadrt_local.py
+++ b/hal_hw_interface/hal_hw_interface/loadrt_local.py
@@ -7,9 +7,9 @@ def loadrt_local(modname):
     """
     Load a RT HAL component.
 
-    Load a locally-built HAL component installed outside standard
-    module directories.  Uses the `LD_LIBRARY_PATH` environment
-    variable as a search path.
+    Load a locally-built HAL component installed outside standard module
+    directories.  Uses the `LD_LIBRARY_PATH` environment variable as a
+    search path.
     """
     if modname in hal.components:
         return

--- a/hal_hw_interface/hal_hw_interface/ros_hal_component.py
+++ b/hal_hw_interface/hal_hw_interface/ros_hal_component.py
@@ -119,10 +119,10 @@ class RosHalComponent(HalObjBase, abc.ABC):
         """
         ROS node and HAL component update routine.
 
-        This MUST be defined in subclasses.  It is run periodically
-        from the :py:func:`run` function, and should take care of all
-        updates, such as reading or writing pins and communication
-        with ROS.
+        This MUST be defined in subclasses.  It is run periodically from
+        the :py:func:`run` function, and should take care of all
+        updates, such as reading or writing pins and communication with
+        ROS.
         """
 
     def main(self):

--- a/hal_hw_interface/package.xml
+++ b/hal_hw_interface/package.xml
@@ -14,7 +14,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>hardware_interface</depend>
   <depend>controller_manager</depend>
@@ -32,7 +31,6 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
   <exec_depend>hal_hw_interface_msgs</exec_depend>
-  <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>machinekit</exec_depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>
@@ -50,8 +48,6 @@
        https://github.com/ros/pluginlib/pull/222 -->
   <depend>libboost-thread</depend>
   <build_depend>libboost-thread-dev</build_depend>
-
-  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This PR is based on #10 and should be reviewed after #10 is resolved.

As the title suggests, this PR contains minor updates to infrastructure, perhaps a continuation of #7 :
- Remove `rosidl`-related package deps from `hal_hw_interface`:  Messages were moved into the `hal_hw_interface_msgs` package, and these were unintentionally left behind
- Add `pep257` formatters to the `pre-commit` configuration:  The `hal_hw_interface/CMakeLists.txt` runs the `ament_pep257` check; this helps catch (and partly automates fix of) related problems before they reach CI
- Add README notes about switching trajectory controllers at runtime
