### PR TITLE
2022 02 08 python port updates

### DIFF
--- a/hal_hw_interface/hal_hw_interface/hal_mgr.py
+++ b/hal_hw_interface/hal_hw_interface/hal_mgr.py
@@ -10,8 +10,6 @@ from std_msgs.msg import Bool
 class HalMgr(RosHalComponent):
     compname = "hal_mgr"
     READY_TOPIC = "hal_mgr/ready"
-    shutdown_begun = False
-    update_rate = 0.1  # sec
 
     def init_hal_comp(self):
         # Don't actually set up any HAL comp

--- a/hal_hw_interface/hal_hw_interface/hal_obj_base.py
+++ b/hal_hw_interface/hal_hw_interface/hal_obj_base.py
@@ -37,7 +37,7 @@ class HalObjBase:
         :returns: HAL component object
         :rtype: :py:class:`hal.component`
         """
-        assert "hal_comp" in self._cached_objs
+        assert "hal_comp" in self._cached_objs, "`init_hal_comp` not called"
         return self._cached_objs["hal_comp"]
 
     def init_ros_node(self, args):
@@ -54,7 +54,7 @@ class HalObjBase:
         :param args:  Args to ROS node, e.g. `sys.argv`
         :type args:  list
         """
-        assert self.compname is not None
+        assert self.compname is not None, "`compname` not set"
         assert "node" not in self._cached_objs
         rclpy.init(args=args)
         co = self._cached_objs
@@ -75,7 +75,7 @@ class HalObjBase:
         :returns: ROS node object
         :rtype: :py:class:`rclpy.node.Node`
         """
-        assert "node" in self._cached_objs
+        assert "node" in self._cached_objs, "`init_ros_node` not called"
         return self._cached_objs["node"]
 
     @property
@@ -91,7 +91,7 @@ class HalObjBase:
         :returns: ROS node context object
         :rtype: :py:class:`rclpy.context.Context`
         """
-        assert "node_context" in self._cached_objs
+        assert "node_context" in self._cached_objs, "`init_ros_node` not called"
         return self._cached_objs["node_context"]
 
     def get_ros_param(self, name, default=None):
@@ -132,7 +132,7 @@ class HalObjBase:
         :param prio: Priority, default 500
         :type prio: int
         """
-        assert callable(cb)
+        assert callable(cb), "shutdown callback must be callable"
         shutdown_cbs = self._cached_objs.setdefault("shutdown_cbs", {})
         while prio in shutdown_cbs:
             prio += 0.1

--- a/hal_hw_interface/hal_hw_interface/hal_obj_base.py
+++ b/hal_hw_interface/hal_hw_interface/hal_obj_base.py
@@ -156,7 +156,6 @@ class HalObjBase:
     def _run_shutdown_cbs(self):
         cb_map = self._cached_objs.setdefault("shutdown_cbs", {})
         if not cb_map:
-            self.logger.info("No more shutdown cbs to run")
             return  # Already run, or none added
         while cb_map:
             top_cb_key = list(cb_map.keys())[0]

--- a/hal_hw_interface/hal_hw_interface/ros_hal_component.py
+++ b/hal_hw_interface/hal_hw_interface/ros_hal_component.py
@@ -110,9 +110,8 @@ class RosHalComponent(HalObjBase, abc.ABC):
         The update rate will be taken from the ROS parameter
         `<compname>/update_rate`, defaulting to 10 Hz.
         """
-        while self.node_context.ok():
-            self.update()
-            rclpy.spin_once(self.node, timeout_sec=1 / self.update_rate)
+        self.node.create_timer(1 / self.update_rate, self.update)
+        rclpy.spin(self.node)
 
     @abc.abstractmethod
     def update(self):
@@ -155,5 +154,7 @@ class RosHalComponent(HalObjBase, abc.ABC):
             self.logger.fatal(f"Exiting on HW interface exception:  {e}")
         except Exception as e:
             self.logger.fatal(f"Exiting on exception:  {e}")
+        except KeyboardInterrupt:
+            self.logger.warn("Shutting down on keyboard interrupt")
         self._run_shutdown_cbs()
         self.node_context.shutdown()

--- a/hal_hw_interface/hal_hw_interface/ros_hal_component.py
+++ b/hal_hw_interface/hal_hw_interface/ros_hal_component.py
@@ -58,11 +58,11 @@ class RosHalComponent(HalObjBase, abc.ABC):
     This will also be used as a default prefix for ROS names.
     """
 
-    def __init__(self, argv):
+    def __init__(self, argv, node_kwargs=dict()):
         assert self.compname is not None, "`compname` not set"
 
         # Create ROS node
-        self.init_ros_node(argv)
+        self.init_ros_node(argv, node_kwargs=node_kwargs)
         self.argv = argv
         self.logger.info(f"Initializing '{self.compname}' component")
 

--- a/hal_hw_interface/hal_hw_interface/ros_hal_component.py
+++ b/hal_hw_interface/hal_hw_interface/ros_hal_component.py
@@ -59,7 +59,7 @@ class RosHalComponent(HalObjBase, abc.ABC):
     """
 
     def __init__(self, argv):
-        assert self.compname is not None
+        assert self.compname is not None, "`compname` not set"
 
         # Create ROS node
         self.init_ros_node(argv)
@@ -81,8 +81,8 @@ class RosHalComponent(HalObjBase, abc.ABC):
         :py:class:`hal_hw_interface.ros_hal_pin.RosHalComponent`
         object setup to initialize the new HAL component
         """
-        assert self.compname is not None
-        assert "hal_comp" not in self._cached_objs
+        assert self.compname is not None, "`compname` not set"
+        assert "hal_comp" not in self._cached_objs, "`init_hal_comp` called"
         self._cached_objs["hal_comp"] = hal.component(self.compname)
 
     @abc.abstractmethod

--- a/hal_hw_interface/hal_hw_interface/tests/conftest.py
+++ b/hal_hw_interface/hal_hw_interface/tests/conftest.py
@@ -161,6 +161,7 @@ def mock_rclpy(request):
             create_publisher=MagicMock(side_effect=create_publisher),
             create_subscription=MagicMock(side_effect=create_subscription),
             create_service=MagicMock(side_effect=create_service),
+            create_timer=MagicMock(name="create_timer"),
         )
         return node
 
@@ -182,7 +183,7 @@ def mock_rclpy(request):
     rclpy.create_node.side_effect = create_node
     rclpy.utilities.get_default_context.return_value = ctx
     rclpy.logging.get_logger.side_effect = get_logger
-    # These don't really need to do anything:  spin_once, init
+    # These don't really need to do anything:  spin, init
 
     # Test instance storage attributes
     request.instance.rosparams = dict()  # Rosparam values by key

--- a/hal_hw_interface/hal_hw_interface/tests/conftest.py
+++ b/hal_hw_interface/hal_hw_interface/tests/conftest.py
@@ -7,12 +7,18 @@ def mock_hal_comp(request):
     # Mock hal.component() __getitem__() method (gets pin value)
     def get_pin_val(key):
         val = request.instance.pvals[key]
-        print(f"Get HAL comp pin {key} = {val}")
+        print(
+            f"  mock_hal_comp:  {request.instance.comp_name}"
+            f".__getitem__('{key}') => {val}"
+        )
         return val
 
     # Mock hal.component() __setitem__() method (sets pin value)
     def set_pin_val(key, val):
-        print(f"Set HAL comp pin {key} = {val}")
+        print(
+            f"  mock_hal_comp:  {request.instance.comp_name}"
+            f".__getitem__('{key}') => {val}"
+        )
         request.instance.pvals[key] = val
 
     # Mock hal.component().newpin() method & object
@@ -53,30 +59,47 @@ def mock_hal_comp(request):
 
 @pytest.fixture()
 def mock_rclpy(request):
+    # Instance must define `rclpy_patches` list of classes to patch
+    assert hasattr(request.instance, "rclpy_patches")
+
     # rclpy.node.Node().declare_parameter():  looks up values in test
     # object `rosparams` attribute
-    def declare_parameter_value_closure(name, default_value):
-        def value():
-            v = request.instance.rosparams.get(name, default_value)
-            print(f"node.declare_parameter({name}).value = {v}")
-            return v
+    def parameter_value_property(name, default_value):
+        default_sentinel = MagicMock(name="default")
 
-        return value
+        def value(v=default_sentinel):
+            if v is not default_sentinel:
+                request.instance.rosparams[name] = v
+                print(f"  mock_rclpy:  set parameter({name}).value = {v}")
+            else:
+                v = request.instance.rosparams.get(name, default_value)
+                print(f"  mock_rclpy:  get parameter({name}).value => {v}")
+                return v
+
+        value_property = PropertyMock(f"param {name}.value", side_effect=value)
+        return value_property
 
     def declare_parameter(name, value=None):
+        if name in request.instance.rosparam_decls:
+            raise RuntimeError(
+                f"Node.declare_parameter({name}):  already declared"
+            )
         dp = MagicMock(name=f"mock_rclpy_declare_parameter({name})")
-        pm = PropertyMock(
-            side_effect=declare_parameter_value_closure(name, value)
-        )
-        type(dp).value = pm
-        print(f"Created PropertyMock {pm}")
+        type(dp).value = parameter_value_property(name, value)
+        request.instance.rosparam_decls[name] = dp
+        print(f"  mock_rclpy:  node.declare_parameter(name, value={value})")
         return dp
+
+    def has_parameter(name):
+        res = name in request.instance.rosparam_decls
+        print(f"  mock_rclpy:  node.has_parameter({name}) = {res}")
+        return res
 
     # rclpy.logging.get_logger():  info(), debug(), fatal() methods
     # print to stdout
     def get_logger_closure(name, level):
         def logger_method(msg_fmt, *args):
-            print(f"{name}.{level}:  {msg_fmt % args}")
+            print(f"logger:  {name}.{level}:  {msg_fmt % args}")
 
         return logger_method
 
@@ -91,21 +114,26 @@ def mock_rclpy(request):
 
     # rclpy.node.Node().create_subscription():  create mock
     # rclpy.publisher.Publisher obj
-    def create_publisher(msg_type, pub_topic):
-        pub_pub = MagicMock(f"Publisher.publish {pub_topic} {str(msg_type)}")
+    def create_publisher(msg_type, pub_topic, qos_profile):
+        desc = f"'{pub_topic}' msg_type={msg_type.__name__}"
+        pub_pub = MagicMock(f"Publisher.publish {desc}")
         pub = request.instance.publishers[pub_topic] = MagicMock(
-            f"Publisher {pub_topic} {str(msg_type)}",
+            name=f"Publisher {desc}",
             publish=pub_pub,
             msg_type=msg_type,
         )
-        print(f"Created Publisher topic={pub_topic}")
+        print(
+            f"  mock_rclpy:  node.create_publisher("
+            f"{msg_type}, {pub_topic}, {qos_profile}"
+        )
         return pub
 
     # rclpy.node.Node().create_subscription():  create mock
     # rclpy.subscription.Subscription obj
     def create_subscription(msg_type, sub_topic, cb):
+        desc = f"'{sub_topic}' msg_type={msg_type.__name__}"
         sub = request.instance.subscriptions[sub_topic] = MagicMock(
-            f"Subscription {sub_topic} {str(msg_type)}",
+            name=f"Subscription {desc}",
             msg_type=msg_type,
             cb=cb,
         )
@@ -114,17 +142,21 @@ def mock_rclpy(request):
     # rclpy.node.Node().create_service():  create mock
     # rclpy.service.Service obj
     def create_service(srv_type, srv_name, cb):
+        desc = f"'{srv_name}' srv_type={srv_type.__name__}"
         srv = request.instance.services[srv_name] = MagicMock(
-            f"Service {srv_name} {str(srv_type)}", srv_type=srv_type, cb=cb
+            name=f"Service {desc}", srv_type=srv_type, cb=cb
         )
         return srv
 
     # rclpy.create_node():  returns mock rclpy.node.Node() object; see
     # above declare_parameter() and get_logger() mock methods
-    def create_node(node_name):
+    def create_node(node_name, **kwargs):
+        kwargs_str = ", ".join([f"{k}={v}" for k, v in kwargs.items()])
+        print(f"  mock_rclpy:  create_node({node_name}, {kwargs_str})")
         node = request.instance.node = MagicMock(
-            f"Node({node_name})",
+            f"Node({node_name}, {kwargs_str})",
             declare_parameter=MagicMock(side_effect=declare_parameter),
+            has_parameter=MagicMock(side_effect=has_parameter),
             get_logger=MagicMock(side_effect=lambda: get_logger(node_name)),
             create_publisher=MagicMock(side_effect=create_publisher),
             create_subscription=MagicMock(side_effect=create_subscription),
@@ -154,6 +186,7 @@ def mock_rclpy(request):
 
     # Test instance storage attributes
     request.instance.rosparams = dict()  # Rosparam values by key
+    request.instance.rosparam_decls = dict()  # Declared rosparams
     request.instance.loggers = dict()  # Loggers by name
     request.instance.publishers = dict()  # Publishers by name
     request.instance.subscriptions = dict()  # Subscriptions by name
@@ -164,10 +197,8 @@ def mock_rclpy(request):
     request.instance.context = ctx  # rclpy.context.Context
     request.instance.rclpy = rclpy  # rclpy import
 
-    patch("hal_hw_interface.hal_mgr.rclpy", rclpy).start()
-    patch("hal_hw_interface.hal_obj_base.rclpy", rclpy).start()
-    patch("hal_hw_interface.loadrt_local.rclpy", rclpy).start()
-    patch("hal_hw_interface.ros_hal_component.rclpy", rclpy).start()
+    for p in request.instance.rclpy_patches:
+        patch(p, rclpy).start()
 
     yield rclpy
 

--- a/hal_hw_interface/hal_hw_interface/tests/hal_io.conf.yaml
+++ b/hal_hw_interface/hal_hw_interface/tests/hal_io.conf.yaml
@@ -1,0 +1,33 @@
+publish_pins:
+  bit_pub:
+    hal_type:  HAL_BIT
+  u32_pub:
+    hal_type:  HAL_U32
+  s32_pub:
+    hal_type:  HAL_S32
+    hal_dir:  HAL_IO
+  float_pub:
+    hal_type:  HAL_FLOAT
+    pub_topic:  float_topic
+subscribe_pins:
+  bit_sub:
+    hal_type:  HAL_BIT
+    sub_topic:  bit_topic
+  u32_sub:
+    hal_type:  HAL_U32
+    hal_dir:  HAL_IO
+  s32_sub:
+    hal_type:  HAL_S32
+  float_sub:
+    hal_type:  HAL_FLOAT
+service_pins:
+  bit_svc:
+    hal_type:  HAL_BIT
+  u32_svc:
+    hal_type:  HAL_U32
+    hal_dir:  HAL_IO
+  s32_svc:
+    hal_type:  HAL_S32
+    service_name:  s32_svc
+  float_svc:
+    hal_type:  HAL_FLOAT

--- a/hal_hw_interface/hal_hw_interface/tests/test_hal_obj_base.py
+++ b/hal_hw_interface/hal_hw_interface/tests/test_hal_obj_base.py
@@ -39,7 +39,9 @@ class TestHalObjBase:
 
         # Check node
         self.rclpy.create_node.assert_called_once()
-        self.rclpy.create_node.assert_called_with(self.comp_name)
+        self.rclpy.create_node.assert_called_with(
+            self.comp_name, context=self.context
+        )
         assert hasattr(obj, "node")
         assert obj.node is self.node
 

--- a/hal_hw_interface/hal_hw_interface/tests/test_hal_obj_base.py
+++ b/hal_hw_interface/hal_hw_interface/tests/test_hal_obj_base.py
@@ -6,6 +6,9 @@ from hal_hw_interface.hal_obj_base import HalObjBase
 class TestHalObjBase:
     comp_name = "test_comp"
     test_class = HalObjBase
+    rclpy_patches = [
+        "hal_hw_interface.hal_obj_base.rclpy",
+    ]
 
     @pytest.fixture
     def obj(self, mock_rclpy, mock_hal_comp):

--- a/hal_hw_interface/hal_hw_interface/tests/test_ros_hal_component.py
+++ b/hal_hw_interface/hal_hw_interface/tests/test_ros_hal_component.py
@@ -67,8 +67,8 @@ class TestRosHalComponent:
         assert res == 13
 
     def test_run(self, obj):
-        # Test run() (fixture loops three times); should call update()
-        # and rate.sleep()
         obj.run()
-        assert obj.count == 3
-        assert self.rclpy.spin_once.call_count == 3
+        self.node.create_timer.assert_called_with(
+            1 / self.rosparams["update_rate"], obj.update
+        )
+        self.rclpy.spin.assert_called_with(self.node)

--- a/hal_hw_interface/hal_hw_interface/tests/test_ros_hal_component.py
+++ b/hal_hw_interface/hal_hw_interface/tests/test_ros_hal_component.py
@@ -18,6 +18,10 @@ class TestRosHalComponent:
 
     test_class = StubComp
     comp_name = test_class.compname
+    rclpy_patches = [
+        "hal_hw_interface.hal_obj_base.rclpy",
+        "hal_hw_interface.ros_hal_component.rclpy",
+    ]
 
     @pytest.fixture
     def obj(self, mock_hal_comp, mock_rclpy):

--- a/hal_hw_interface/hal_hw_interface/tests/test_ros_hal_pin.py
+++ b/hal_hw_interface/hal_hw_interface/tests/test_ros_hal_pin.py
@@ -24,6 +24,10 @@ from ..ros_hal_component import RosHalComponent
 class TestRosHalPin:
     test_class = RosHalPin
     comp_name = "mock_hal_comp"  # conftest.py
+    rclpy_patches = [
+        "hal_hw_interface.hal_obj_base.rclpy",
+        "hal_hw_interface.ros_hal_component.rclpy",
+    ]
 
     #
     # Object and data fixtures

--- a/hal_hw_interface/hal_hw_interface/tests/test_ros_hal_pin.py
+++ b/hal_hw_interface/hal_hw_interface/tests/test_ros_hal_pin.py
@@ -233,7 +233,7 @@ class TestRosHalPinPublisher(TestRosHalPin):
         assert obj.pub_topic == self.case["pub_topic"]
         print(self.node.create_publisher.mock_calls)
         self.node.create_publisher.assert_called_with(
-            self.msg_type, self.case["pub_topic"]
+            self.msg_type, self.case["pub_topic"], 1
         )
         assert obj.pub is self.publishers[self.case["pub_topic"]]
 
@@ -260,10 +260,7 @@ class TestRosHalPinPublisher(TestRosHalPin):
 
         # Check calls
         print(f"pub.publish calls:  {obj.pub.publish.mock_calls}")
-        if pvals["changed"]:
-            obj.pub.publish.assert_called_with(obj._msg)
-        else:
-            obj.pub.publish.assert_not_called()
+        obj.pub.publish.assert_called_with(obj._msg)
 
 
 class TestRosHalPinSubscriber(TestRosHalPinPublisher):
@@ -301,12 +298,7 @@ class TestRosHalPinSubscriber(TestRosHalPinPublisher):
         self.print_debug_info("msg.data", msg.data)
 
         obj._subscriber_cb(msg)
-        if pvals["changed"]:
-            self.hal_comp.__setitem__.assert_called_with(
-                self.pin_name, new_value
-            )
-        else:
-            self.hal_comp.__setitem__.assert_not_called()
+        self.hal_comp.__setitem__.assert_called_with(self.pin_name, new_value)
 
         # Test that wrong msg type raises exception
         with pytest.raises(HalHWInterfaceException):

--- a/hal_hw_interface/scripts/hal_io
+++ b/hal_hw_interface/scripts/hal_io
@@ -32,6 +32,7 @@
 # SUCH DAMAGE.
 
 from hal_hw_interface.hal_io_comp import HalIO
+import sys
 
 if __name__ == "__main__":
-    HalIO().main()
+    HalIO(sys.argv[1:]).main()


### PR DESCRIPTION
This PR follows #11 , and should be reviewed after that one is resolved.

This PR fixes Python issues remaining from #9:
- Shut down ROS nodes gracefully:  Shutdown after `KeyboardInterrupt` without dumping traceback messages and without logger warnings
- Fix ROS2 parameter handling:  Account for semantic differences in ROS2 parameters, esp. params may be declared once, and mixed `dict` params no longer supported
- Fix ROS2 topics:  Address problems found after real tests (as opposed to unit tests)
- Add explanations to `assert` statements:  Human-readable error messages make these assertions even more useful!