### PR TITLE
2022 03 02 updates

### DIFF
--- a/hal_hw_interface/hal_hw_interface/hal_io_comp.py
+++ b/hal_hw_interface/hal_hw_interface/hal_io_comp.py
@@ -30,6 +30,11 @@ class HalIO(RosHalComponent):
             digital_out_1:
               hal_type: BIT
               hal_dir: IN
+              log_changes: true
+            status_word:
+              hal_type: U32
+              hal_dir: OUT
+              log_changes: debug
           service_pins:
             encoder_scale:
               hal_type: FLOAT

--- a/hal_hw_interface/hal_hw_interface/hal_mgr.py
+++ b/hal_hw_interface/hal_hw_interface/hal_mgr.py
@@ -68,6 +68,7 @@ class HalMgr(RosHalComponent):
         try:
             subprocess.check_call(["halcmd", "stop"])
             subprocess.check_call(["halcmd", "unloadrt", "all"])
+            subprocess.check_call(["halcmd", "unload", "all"])
         finally:
             subprocess.check_call(["realtime", "stop"])
             self.logger.info("Realtime stopped")

--- a/hal_hw_interface/hal_hw_interface/launch/hal_ordered_action.py
+++ b/hal_hw_interface/hal_hw_interface/launch/hal_ordered_action.py
@@ -294,7 +294,6 @@ class HalThreadedReadyAction(HalAsyncReadyAction):
             return False
         else:
             if not self.__joined:
-                self.__logger.info(f"HAL action {self.hal_name} thread exited")
                 self.__thread.join()
                 self.__joined = True
             return True

--- a/hal_hw_interface/src/hal_control_node.cpp
+++ b/hal_hw_interface/src/hal_control_node.cpp
@@ -167,12 +167,6 @@ int rtapi_app_main(void)
       std::chrono::milliseconds(10), reset_controller_cb);
   EXECUTOR->add_node(CONTROLLER_MANAGER);
 
-  // Some race condition causes segfault; this seems to take care of it.
-  // Related?
-  // https://github.com/firesurfer/ros2_components/blob/master/src/ros2_components/ManagedNode.cpp#L200
-  HAL_ROS_DBG_NAMED(CNAME, "Sleeping to avoid segfault :P");
-  sleep(2);
-
   // ROS asynch executor thread pointer
   HAL_ROS_DBG_NAMED(CNAME, "Starting executor");
   auto executor_cb = []() { EXECUTOR->spin(); };


### PR DESCRIPTION
This PR contains various small changes added while bringing up a real hardware configuration.  Each commit should be self explanatory.  I can break this up into smaller PRs if desired.  Here's a summary:

- Remove the `sleep()` call during controller node setup; the segfaults this prevented magically stopped since it was first introduced
- Add HAL pins to the controller node for showing the max execution time of controller manager `read()`/`update()`/`write()` calls; this helped locate RT overruns in `ros2_controllers`
- Unload HAL user components at shutdown (e.g. `lcec_conf`)
- Make Python HAL pin value change logging optional; avoids a lot of console spamming for some configurations
- Log message tweaks

