### PR TITLE
Foxy devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ output pins with `std_msgs` publishers and subscribers, respectively.
 
 [machinekit]:  http://machinekit.io
 [ros2_control]: https://github.com/ros-controls/ros2_control
-
+[ros2_control_demos]:https://github.com/ros-controls/ros2_control_demos
 ## The `hal_hw_interface` real-time component
 
 The `hal_control_node` HAL component runs a
@@ -67,7 +67,7 @@ start netting pins before the HAL components are loaded and ready.
 - [`ros2_control`][ros2_control]
   - Required by the `hal_hw_interface`
   - This may be installed in package form
-- Optional:  The `ros2_control_demos` repo
+- Optional:  The [`ros2_control_demos`][ros2_control_demos] repo
   - Required to run the `hal_rrbot_control` demo
   - This may also be installed in package form
   - Follow the notes in that project's README to install

--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ start netting pins before the HAL components are loaded and ready.
 - A real-time kernel, either RT_PREEMPT or Xenomai
   - Required by Machinekit for low-latency control
   - See the `linux-image-rt-*` packages available in Debian Stretch.
-- [`ros_control_boilerplate`][ros_control_boilerplate]
+- [`ros2_control`][ros2_control]
   - Required by the `hal_hw_interface`
   - This may be installed in package form
 - Optional:  The `ros2_control_demos` repo
   - Required to run the `hal_rrbot_control` demo
+  - This may also be installed in package form
   - Follow the notes in that project's README to install
 
 -----

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Run the simulated hardware interface:
     ros2 launch hal_rrbot_control rrbot.launch.py
     # Debugging: append `hal_debug_output:=1 hal_debug_level:=5`
     # Trajectory controller:  append
-    #     `robot_controller:=position_trajectory_controller`
+    #     `robot_controller:=joint_trajectory_position_controller`
 
 Run `halscope` to visualize HAL joint commands and feedback; in the
 GUI, set the "Run Mode" to "Roll" for continuous updating:
@@ -96,8 +96,8 @@ The simulated trajectories are launched directly from the
 `ros2_control_demo_bringup` package:
 
     ros2 launch ros2_control_demo_bringup test_forward_position_controller.launch.py
-    # Or for robot_controller:=position_trajectory_controller:
-    ros2 launch ros2_control_demo_bringup test_joint_trajectory_controller.launch.py
+    # Or for robot_controller:=joint_trajectory_position_controller:
+    ros2 launch ros2_control_demo_bringup test_joint_trajectory_position_controller.launch.py
 
 Load and switch to the trajectory controller at run time:
 
@@ -105,19 +105,19 @@ Load and switch to the trajectory controller at run time:
     ros2 service call \
       /controller_manager/load_and_configure_controller \
       controller_manager_msgs/srv/LoadConfigureController \
-      '{name: "position_trajectory_controller"}'
+      '{name: "joint_trajectory_position_controller"}'
 
     # Switch to the trajectory controller
     ros2 service call \
       /controller_manager/switch_controller \
       controller_manager_msgs/srv/SwitchController \
-      '{start_controllers: ["position_trajectory_controller"],
+      '{start_controllers: ["joint_trajectory_position_controller"],
         stop_controllers: ["forward_position_controller"],
         strictness: 1, start_asap: true,
         timeout: {sec: 0, nanosec: 10000000}
        }'
 
-    # Verify the switch: 'position_trajectory_controller' state='active'
+    # Verify the switch: 'joint_trajectory_position_controller' state='active'
     ros2 service call \
       /controller_manager/list_controllers \
       controller_manager_msgs/srv/ListControllers

--- a/hal_hw_interface/cmake/FindHAL.cmake
+++ b/hal_hw_interface/cmake/FindHAL.cmake
@@ -24,8 +24,8 @@ set(MACHINEKIT_RIP_PATH
 
 # HAL_INCLUDE_PATH:  Find HAL include directory
 find_path(
-  HAL_INCLUDE_PATH hal.h
-  PATH_SUFFIXES machinekit
+  HAL_INCLUDE_PATH hal/hal.h
+  PATH_SUFFIXES machinekit/hal
   PATHS ${MACHINEKIT_RIP_PATH}/include
 )
 

--- a/hal_hw_interface/hal_hw_interface/hal_mgr.py
+++ b/hal_hw_interface/hal_hw_interface/hal_mgr.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from machinekit import config
+#from machinekit import config
 from .ros_hal_component import RosHalComponent
 
 # ROS
@@ -52,7 +52,7 @@ class HalMgr(RosHalComponent):
         env = dict(
             DEBUG=d_lev,
             SYSLOG_TO_STDERR=d_out,
-            MACHINEKIT_INI=config.Config().MACHINEKIT_INI,
+            MACHINEKIT_INI="/etc/machinekit/hal/machinekit.ini",
             FASTRTPS_DEFAULT_PROFILES_FILE=fastrtps_profiles,
             **os.environ,
         )

--- a/hal_hw_interface/hal_hw_interface/hal_pin_attrs.py
+++ b/hal_hw_interface/hal_hw_interface/hal_pin_attrs.py
@@ -1,4 +1,4 @@
-import hal
+import machinekit.hal.pyhal as hal
 
 
 class HalPinAttrBase(int):

--- a/hal_hw_interface/hal_hw_interface/launch/hal_ordered_action.py
+++ b/hal_hw_interface/hal_hw_interface/launch/hal_ordered_action.py
@@ -14,7 +14,7 @@ from launch.events import Shutdown
 
 from launch_ros.actions import Node
 
-from machinekit import rtapi
+from machinekit.hal.cyruntime import rtapi
 from .hal_ready import HalReady
 
 

--- a/hal_hw_interface/hal_hw_interface/launch/hal_rt_node.py
+++ b/hal_hw_interface/hal_hw_interface/launch/hal_rt_node.py
@@ -6,7 +6,8 @@ from launch.utilities import perform_substitutions
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.substitutions import FindPackagePrefix
 
-from machinekit import rtapi, hal
+from machinekit.hal.cyruntime import rtapi
+import machinekit.hal.pyhal as hal
 from .hal_ordered_action import HalOrderedNode, HalThreadedReadyAction
 
 

--- a/hal_hw_interface/hal_hw_interface/launch/hal_rt_node.py
+++ b/hal_hw_interface/hal_hw_interface/launch/hal_rt_node.py
@@ -7,7 +7,7 @@ from launch.substitutions import PathJoinSubstitution
 from launch_ros.substitutions import FindPackagePrefix
 
 from machinekit.hal.cyruntime import rtapi
-import machinekit.hal.pyhal as hal
+import machinekit.hal.cyhal as hal
 from .hal_ordered_action import HalOrderedNode, HalThreadedReadyAction
 
 

--- a/hal_hw_interface/hal_hw_interface/launch/hal_user_node.py
+++ b/hal_hw_interface/hal_hw_interface/launch/hal_user_node.py
@@ -1,5 +1,5 @@
 import os
-from machinekit import hal
+import machinekit.hal.pyhal as hal
 from launch import logging
 from .hal_ordered_action import HalOrderedNode, HalAsyncReadyAction
 

--- a/hal_hw_interface/hal_hw_interface/launch/hal_user_node.py
+++ b/hal_hw_interface/hal_hw_interface/launch/hal_user_node.py
@@ -1,5 +1,5 @@
 import os
-import machinekit.hal.pyhal as hal
+import machinekit.hal.cyhal as hal
 from launch import logging
 from .hal_ordered_action import HalOrderedNode, HalAsyncReadyAction
 

--- a/hal_hw_interface/hal_hw_interface/loadrt_local.py
+++ b/hal_hw_interface/hal_hw_interface/loadrt_local.py
@@ -1,7 +1,7 @@
 import rclpy
 import os
-from machinekit import rtapi, hal
-
+from machinekit.hal.cyruntime import rtapi
+import machinekit.hal.pyhal as hal
 
 def loadrt_local(modname):
     """

--- a/hal_hw_interface/hal_hw_interface/ros_hal_component.py
+++ b/hal_hw_interface/hal_hw_interface/ros_hal_component.py
@@ -5,7 +5,7 @@
 """
 
 import abc
-import hal
+import machinekit.hal.pyhal as hal
 import rclpy
 from .hal_obj_base import HalObjBase
 from .exception import HalHWInterfaceException

--- a/hal_hw_interface/hal_hw_interface/tests/test_hal_pin_attrs.py
+++ b/hal_hw_interface/hal_hw_interface/tests/test_hal_pin_attrs.py
@@ -1,5 +1,5 @@
 import pytest
-import hal
+import machinekit.hal.pyhal as hal
 
 from hal_hw_interface.hal_pin_attrs import HalPinDir, HalPinType
 

--- a/hal_hw_interface/include/hal_hw_interface/hal_ros_logging.hpp
+++ b/hal_hw_interface/include/hal_hw_interface/hal_ros_logging.hpp
@@ -33,7 +33,7 @@
 #define HAL_HW_INTERFACE__HAL_ROS_LOGGING_HPP_
 
 // HAL
-#include <hal.h>
+#include <hal/hal.h>
 
 // ROS
 #include <rclcpp/logging.hpp>

--- a/hal_hw_interface/include/hal_hw_interface/hal_system_interface.hpp
+++ b/hal_hw_interface/include/hal_hw_interface/hal_system_interface.hpp
@@ -37,7 +37,7 @@
 #endif
 
 // HAL
-#include <hal.h>
+#include <hal/hal.h>
 
 #include <string>
 #include <vector>

--- a/hal_hw_interface/src/hal_control_node.cpp
+++ b/hal_hw_interface/src/hal_control_node.cpp
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <pthread.h>  // pthread_setname_np()
 #include <unistd.h>   // sleep()
-#include <hal.h>      // HAL public API decls
+#include <hal/hal.h>      // HAL public API decls
 #include <rclcpp/rclcpp.hpp>
 #include <controller_manager/controller_manager.hpp>
 #include <controller_manager_msgs/srv/switch_controller.hpp>

--- a/hal_hw_interface/src/hal_system_interface.cpp
+++ b/hal_hw_interface/src/hal_system_interface.cpp
@@ -32,8 +32,8 @@
 // Disable warnings that need to be fixed in external headers
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
-#include <hal.h>       // HAL public API decls
-#include <hal_priv.h>  // halpr_find_comp_by_name
+#include <hal/hal.h>       // HAL public API decls
+#include <hal/hal_priv.h>  // halpr_find_comp_by_name
 #pragma GCC diagnostic pop
 
 #include <hal_hw_interface/hal_system_interface.hpp>


### PR DESCRIPTION
Basicly a rework of the python import structure as to work in the current machinekit-hal repo.

Demo Tested to work on Ubuntu 20.04 LTS arm64 ~except:~
 ~changing to the trajectory controller,~
~which does not show up in the interface list.~
There was a typo in the readme.... fix commit added